### PR TITLE
Add warning about react-app-rewired and cra 2.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 - English: https://ant.design/docs/react/use-with-create-react-app
 - 中文：https://ant.design/docs/react/use-with-create-react-app-cn
 
+⚠️ [react-app-rewired](https://github.com/timarney/react-app-rewired) which is used to configure create-react-app and avoid to eject, is no more maintained and doesn't officialy support create-react-app 2.X (notably some plugins may break due to changes in webpack, see https://github.com/timarney/react-app-rewired/issues/162). However, it works with CRA 2.1.1, ant-design and react-app-rewire-less and thus you can still use it (at your own risk) .
+
 ## Preview
 
 ```bash


### PR DESCRIPTION
React-app-rewired doesn't officialy support CRA 2.X. (see https://github.com/timarney/react-app-rewired/issues/162)
However, I didn't notice any bug with cra 2.1.1, antd 3.10.5 (and even typescript loader), and besides the alternatives to react-app-rewired (customize-cra, craco) don't support less.

It seems better to warn the user anyway because it may break in the future.