### PR TITLE
Correcting customize cra setup

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -8,7 +8,10 @@ module.exports = override(
   addLessLoader({
     lessOptions: {
       javascriptEnabled: true,
-      modifyVars: { '@primary-color': '#25b864' },
+      modifyVars: {
+        '@primary-color': '#25b864',
+        '@border-radius-base': '6px',
+      },
     },
-  }),
+  })
 );

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "antd": "^4.2.0",
     "babel-plugin-import": "^1.13.0",
-    "customize-cra": "^0.9.1",
+    "customize-cra": "^1.0.0-alpha.0",
     "less": "^3.11.1",
     "less-loader": "^6.1.0",
     "react": "^16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3612,10 +3612,10 @@ cssstyle@^1.0.0, cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-customize-cra@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.npm.taobao.org/customize-cra/download/customize-cra-0.9.1.tgz#76b42c4f537c16329eccc09cfefd804d04c81550"
-  integrity sha1-drQsT1N8FjKezMCc/v2ATQTIFVA=
+customize-cra@^1.0.0-alpha.0:
+  version "1.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/customize-cra/-/customize-cra-1.0.0-alpha.0.tgz#7a9523a93d0720cd2190dc24137691b981abf185"
+  integrity sha512-Ve/D8ZWGLIfW/rKO0dXmEB4rpstxs0rNlnU3eoYU5ijwZljpJVpLheIoTuGJi+poqFhn1YNkNx7zFVpZNnK5ig==
   dependencies:
     lodash.flow "^3.5.0"
 


### PR DESCRIPTION
Hi, just a minor PR for correcting the issue starting with this repo with customize-cra bump to 1.0.0 according to doc [antd](https://ant.design/docs/react/use-with-create-react-app)
less-loader bumped to @^6 but not compatible as-is with customize-cra before @^1
Also proposal for border-radius-base in `config-overrides.js`.